### PR TITLE
Update Packers schedule with recent game results and Wild Card playoff

### DIFF
--- a/src/utils/getNextGames.js
+++ b/src/utils/getNextGames.js
@@ -378,14 +378,23 @@ const schedule = [
   {
     dateOfMatch: "2025-12-27T19:00:00.000-06:00",
     opponent: "Baltimore Ravens",
+    outcome: "L",
+    score: "24-41",
     network: "Peacock"
   },
   {
     dateOfMatch: "2026-01-04T12:00:00.000-06:00",
     opponent: "at Minnesota Vikings",
-    network: "TBD"
+    outcome: "L",
+    score: "3-16",
+    network: "FOX"
   },
   // Playoffs 2025
+  {
+    dateOfMatch: "2026-01-10T19:00:00.000-06:00",
+    eventName: "Wild Card: Packers vs Chicago Bears",
+    network: "TBD"
+  },
   {
     dateOfMatch: "2026-01-18T00:00:00.000-06:00",
     eventName: "Divisional Playoff Weekend"

--- a/src/utils/getNextGames.js
+++ b/src/utils/getNextGames.js
@@ -393,7 +393,7 @@ const schedule = [
   {
     dateOfMatch: "2026-01-10T19:00:00.000-06:00",
     eventName: "Wild Card: Packers vs Chicago Bears",
-    network: "TBD"
+    network: "Amazon / DAZN"
   },
   {
     dateOfMatch: "2026-01-18T00:00:00.000-06:00",


### PR DESCRIPTION
- Add Ravens game result: L 24-41 (Dec 27, 2025)
- Add Vikings game result: L 3-16 (Jan 4, 2026)
- Add Wild Card playoff game: Packers vs Bears (Jan 10, 2026 at 8pm EST)