### PR TITLE
Add inline attributions and sources footer to May 2026 offseason post


### DIFF
--- a/src/content/blog/en/2026-05-offseason-update.md
+++ b/src/content/blog/en/2026-05-offseason-update.md
@@ -24,9 +24,9 @@ Every offseason has its losses, and this one stung.
 
 **Romeo Doubs** walks after four seasons in Green Bay. The man who led the team in receiving in 2025 — 55 catches, 724 yards, six touchdowns — is gone. For a Jordan Love offense that desperately needs playmakers, losing your most reliable target is a significant blow. The two sides couldn't get a deal done, and Doubs is someone else's problem to cover now.
 
-**Malik Willis** cashed in big time. The backup QB signed a three-year, $67.5 million deal with the Miami Dolphins — starter money. Good for him. His time in Green Bay helped him develop, and the Dolphins clearly see the upside. Wherever Willis goes, Packers fans will cheer for him.
+**Malik Willis** cashed in big time. Per ESPN's free agency tracker, the backup QB signed a three-year, $67.5 million deal with the Miami Dolphins — starter money. Good for him. His time in Green Bay helped him develop, and the Dolphins clearly see the upside. Wherever Willis goes, Packers fans will cheer for him.
 
-On defense, the losses pile up. **Quay Walker**, who was growing into a legitimate starting linebacker, signed a three-year, $40.5 million deal ($28M guaranteed) elsewhere. He was only getting better. **Kingsley Enagbare** headed to the New York Jets on a one-year, $10 million contract. And **Rasheed Walker** departed for the Carolina Panthers on a one-year deal. The linebacker and defensive line rooms look very different heading into the summer.
+On defense, the losses pile up. According to ESPN, **Quay Walker** — who was growing into a legitimate starting linebacker — signed a three-year, $40.5 million deal with $28M guaranteed elsewhere. He was only getting better. **Kingsley Enagbare** headed to the New York Jets on a one-year, $10 million contract. And **Rasheed Walker** departed for the Carolina Panthers on a one-year deal. The linebacker and defensive line rooms look very different heading into the summer.
 
 ---
 
@@ -36,17 +36,17 @@ General Manager Brian Gutekunst didn't sit on his hands.
 
 The biggest acquisition was a **trade for linebacker Zaire Franklin** from the Indianapolis Colts. Franklin is a proven veteran presence — exactly the kind of experienced voice a young defense needs after losing Walker. He fills the communication and leadership void at linebacker.
 
-**Center Sean Rhyan** earned a new contract after stepping into the starting lineup midseason and never looking back — he started the final seven regular season games plus the playoff game. Continuity up front matters, and Rhyan staying keeps the offensive line intact.
+Per Packers.com, **center Sean Rhyan** earned a new contract after stepping into the starting lineup midseason and never looking back — he started the final seven regular season games plus the playoff game. Continuity up front matters, and Rhyan staying keeps the offensive line intact.
 
-Defensive back **Cox** was retained on a one-year, $2.5 million deal. Smart, cost-effective depth.
+Defensive back **Cox** was retained on a one-year, $2.5 million deal, per Lombardi Ave's free agency tracker. Smart, cost-effective depth.
 
 ---
 
 ## The 2026 NFL Draft: Quality Over Quantity
 
-Green Bay entered the draft with eight picks and came out with six selections — the smallest draft class under Brian Gutekunst's tenure, and the smallest Packers class since 2004. The message was clear: swing for high-ceiling talent rather than filling every hole with warm bodies.
+Green Bay entered the draft with eight picks and came out with six selections — the smallest draft class under Brian Gutekunst's tenure, and the smallest Packers class since 2004, per Acme Packing Company. The message was clear: swing for high-ceiling talent rather than filling every hole with warm bodies.
 
-**Round 2, Pick 52 — CB Cisse:** The headline move. At just 20 years old, Cisse is one of the youngest players in the entire draft class, but scouts project him as a future CB1. Reports indicate Gutekunst and his staff were "very high" on him throughout the pre-draft process. Cornerback was a glaring need, and the Packers went out and got someone they believe can be special.
+**Round 2, Pick 52 — CB Cisse:** The headline move. At just 20 years old, Cisse is one of the youngest players in the entire draft class, but scouts project him as a future CB1. Per Acme Packing Company's draft recap, Gutekunst and his staff were "very high" on him throughout the pre-draft process. Cornerback was a glaring need, and the Packers went out and got someone they believe can be special.
 
 **Round 3 (trade-up) — DL McClellan:** Green Bay moved up seven spots from 84, surrendering a fifth-round pick to land McClellan. He's a versatile interior presence — can anchor the nose but also generate some pass rush. After losing Enagbare, adding a young defensive lineman with upside was important.
 
@@ -54,13 +54,13 @@ Green Bay entered the draft with eight picks and came out with six selections �
 
 **Round 6 — CB Domani Jackson:** More competition and depth in the secondary. After drafting Cisse, you double down on what you believe in.
 
-**Undrafted Free Agents:** Ten players were added post-draft, including Virginia Tech quarterback **Kyron Drones** — a dual-threat passer who appeared in 41 games with 32 starts in college (5,785 yards, 45 TDs). He won't threaten Jordan Love's job, but a developmental QB with his athleticism is exactly the kind of camp story that keeps things interesting.
+**Undrafted Free Agents:** Per Packers.com, ten players were added post-draft, including Virginia Tech quarterback **Kyron Drones** — a dual-threat passer who appeared in 41 games with 32 starts in college (5,785 yards, 45 TDs). He won't threaten Jordan Love's job, but a developmental QB with his athleticism is exactly the kind of camp story that keeps things interesting.
 
 ---
 
 ## Jordan Love and What It All Means
 
-Love enters year two of his four-year, $220 million contract ($55M average annually). He's under contract through the heart of this rebuild, and this offseason signals that Gutekunst is doubling down on building around him with young talent rather than expensive veterans.
+Per Spotrac, Love enters year two of his four-year, $220 million contract ($55M average annually, with $160.3M guaranteed). He's under contract through the heart of this rebuild, and this offseason signals that Gutekunst is doubling down on building around him with young talent rather than expensive veterans.
 
 The 2025 season showed the ceiling — Love can play at a high level, and when the offense clicks, the Packers can beat anyone. The 2025 season also showed the floor — when the team goes cold, they *really* go cold. Five straight losses. A 21-3 halftime lead squandered.
 
@@ -73,3 +73,14 @@ After three straight first-round exits, 2026 needs to be the year Green Bay gets
 ---
 
 *Want to watch the 2026 season with fellow Packers fans in Brazil? Check out our [chapters page](/chapters/) to find a watch party near you, or join the [Cabeça de Queijo WhatsApp community](/join/).*
+
+---
+
+### Sources
+
+- [Packers 2026 Free Agency Tracker — ESPN](https://www.espn.com/nfl/story/_/id/48089099/green-bay-packers-2026-free-agency-tracker-offseason-moves-signings-contract)
+- [2026 League Year Begins: Free Agency Rundown — Packers.com](https://www.packers.com/news/2026-league-year-begins-for-packers-with-start-of-nfl-free-agency)
+- [Packers Sign 5 Draft Picks, 10 Rookie Free Agents — Packers.com](https://www.packers.com/news/packers-sign-5-draft-picks-10-rookie-free-agents-may-1-2026)
+- [2026 Packers Draft Class Recap — Acme Packing Company](https://www.acmepackingcompany.com/green-bay-packers-draft/81939/nfl-draft-results-2026-packers-class-rookies-recap)
+- [Packers Free-Agency Tracker 2026 — Lombardi Ave](https://lombardiave.com/green-bay-packers-free-agency-tracker-hub)
+- [Jordan Love Contract Details — Spotrac](https://www.spotrac.com/nfl/player/_/id/47621/jordan-love)

--- a/src/content/blog/en/2026-05-offseason-update.md
+++ b/src/content/blog/en/2026-05-offseason-update.md
@@ -1,0 +1,75 @@
+---
+draft: false
+title: "Packers 2026 Offseason Update: A New Look Roster Takes Shape"
+snippet: "The 2025 season ended in heartbreak, but Green Bay has been busy reshaping the roster. Here's everything that happened this offseason — free agency, the draft, and what it all means for Jordan Love's crew heading into 2026."
+image: {
+    src: "lambeauLeap.jpeg",
+    alt: "Lambeau Leap at Lambeau Field — Green Bay Packers fans celebrating"
+}
+publishDate: "2026-05-19 09:00"
+author: "Cory Trimm"
+category: "Offseason"
+tags: [Offseason, "Free Agency", "NFL Draft", "Jordan Love", "2026"]
+---
+
+The 2025 season left a bitter taste. A 9-8 record. A Wild Card appearance against the Chicago Bears that turned into one of the franchise's most painful collapses — up 21-3 at halftime, then watching it all slip away in a 27-31 defeat. Five straight losses to close the year. If there's a silver lining to a gut-punch ending like that, it's this: it lights a fire under everyone — players, coaches, and front office alike.
+
+The 2026 offseason has been anything but quiet. Let's break down what happened.
+
+---
+
+## Free Agency: The Painful Goodbyes
+
+Every offseason has its losses, and this one stung.
+
+**Romeo Doubs** walks after four seasons in Green Bay. The man who led the team in receiving in 2025 — 55 catches, 724 yards, six touchdowns — is gone. For a Jordan Love offense that desperately needs playmakers, losing your most reliable target is a significant blow. The two sides couldn't get a deal done, and Doubs is someone else's problem to cover now.
+
+**Malik Willis** cashed in big time. The backup QB signed a three-year, $67.5 million deal with the Miami Dolphins — starter money. Good for him. His time in Green Bay helped him develop, and the Dolphins clearly see the upside. Wherever Willis goes, Packers fans will cheer for him.
+
+On defense, the losses pile up. **Quay Walker**, who was growing into a legitimate starting linebacker, signed a three-year, $40.5 million deal ($28M guaranteed) elsewhere. He was only getting better. **Kingsley Enagbare** headed to the New York Jets on a one-year, $10 million contract. And **Rasheed Walker** departed for the Carolina Panthers on a one-year deal. The linebacker and defensive line rooms look very different heading into the summer.
+
+---
+
+## Free Agency: The Moves Made
+
+General Manager Brian Gutekunst didn't sit on his hands.
+
+The biggest acquisition was a **trade for linebacker Zaire Franklin** from the Indianapolis Colts. Franklin is a proven veteran presence — exactly the kind of experienced voice a young defense needs after losing Walker. He fills the communication and leadership void at linebacker.
+
+**Center Sean Rhyan** earned a new contract after stepping into the starting lineup midseason and never looking back — he started the final seven regular season games plus the playoff game. Continuity up front matters, and Rhyan staying keeps the offensive line intact.
+
+Defensive back **Cox** was retained on a one-year, $2.5 million deal. Smart, cost-effective depth.
+
+---
+
+## The 2026 NFL Draft: Quality Over Quantity
+
+Green Bay entered the draft with eight picks and came out with six selections — the smallest draft class under Brian Gutekunst's tenure, and the smallest Packers class since 2004. The message was clear: swing for high-ceiling talent rather than filling every hole with warm bodies.
+
+**Round 2, Pick 52 — CB Cisse:** The headline move. At just 20 years old, Cisse is one of the youngest players in the entire draft class, but scouts project him as a future CB1. Reports indicate Gutekunst and his staff were "very high" on him throughout the pre-draft process. Cornerback was a glaring need, and the Packers went out and got someone they believe can be special.
+
+**Round 3 (trade-up) — DL McClellan:** Green Bay moved up seven spots from 84, surrendering a fifth-round pick to land McClellan. He's a versatile interior presence — can anchor the nose but also generate some pass rush. After losing Enagbare, adding a young defensive lineman with upside was important.
+
+**Round 5 — C/G Jager Burton:** Offensive line depth with position flexibility — always useful.
+
+**Round 6 — CB Domani Jackson:** More competition and depth in the secondary. After drafting Cisse, you double down on what you believe in.
+
+**Undrafted Free Agents:** Ten players were added post-draft, including Virginia Tech quarterback **Kyron Drones** — a dual-threat passer who appeared in 41 games with 32 starts in college (5,785 yards, 45 TDs). He won't threaten Jordan Love's job, but a developmental QB with his athleticism is exactly the kind of camp story that keeps things interesting.
+
+---
+
+## Jordan Love and What It All Means
+
+Love enters year two of his four-year, $220 million contract ($55M average annually). He's under contract through the heart of this rebuild, and this offseason signals that Gutekunst is doubling down on building around him with young talent rather than expensive veterans.
+
+The 2025 season showed the ceiling — Love can play at a high level, and when the offense clicks, the Packers can beat anyone. The 2025 season also showed the floor — when the team goes cold, they *really* go cold. Five straight losses. A 21-3 halftime lead squandered.
+
+The roster looks different now. The weapons are changing. New pieces are coming in. But the goal is the same: take the next step, get back in the playoffs, and stop losing early.
+
+After three straight first-round exits, 2026 needs to be the year Green Bay gets past the opening weekend.
+
+**Go Pack Go. 💛💚**
+
+---
+
+*Want to watch the 2026 season with fellow Packers fans in Brazil? Check out our [chapters page](/chapters/) to find a watch party near you, or join the [Cabeça de Queijo WhatsApp community](/join/).*

--- a/src/content/blog/pt-BR/2026-05-offseason-update.md
+++ b/src/content/blog/pt-BR/2026-05-offseason-update.md
@@ -1,0 +1,75 @@
+---
+draft: false
+title: "Atualização da Offseason 2026 dos Packers: Um Novo Elenco Toma Forma"
+snippet: "A temporada de 2025 terminou com uma dor no coração, mas Green Bay não perdeu tempo reformulando o time. Confira tudo o que aconteceu nesta offseason — agência livre, o draft e o que tudo isso significa para o grupo do Jordan Love em 2026."
+image: {
+    src: "lambeauLeap.jpeg",
+    alt: "Lambeau Leap no Lambeau Field — torcida dos Green Bay Packers comemorando"
+}
+publishDate: "2026-05-19 09:00"
+author: "Cory Trimm"
+category: "Offseason"
+tags: [Offseason, "Agência Livre", "NFL Draft", "Jordan Love", "2026"]
+---
+
+A temporada de 2025 deixou um gosto amargo. Um recorde de 9-8. Uma aparição no Wild Card contra o Chicago Bears que se transformou em um dos colapsos mais dolorosos da história do franchise — vencendo por 21-3 no intervalo, e depois assistindo tudo desmoronar numa derrota de 27-31. Cinco derrotas seguidas para fechar o ano. Se existe um lado positivo para um final assim, é este: ele acende o fogo em todos — jogadores, treinadores e diretoria.
+
+A offseason de 2026 não foi nada quieta. Vamos desempacotar o que aconteceu.
+
+---
+
+## Agência Livre: As Partidas Dolorosas
+
+Toda offseason tem suas perdas, e essa doeu.
+
+**Romeo Doubs** vai embora após quatro temporadas em Green Bay. O homem que liderou o time em recepções em 2025 — 55 recepções, 724 jardas, seis touchdowns — está fora. Para um ataque de Jordan Love que precisa desesperadamente de artilheiros, perder seu alvo mais confiável é um golpe significativo. Os dois lados não conseguiram chegar a um acordo, e Doubs agora é problema de outra equipe.
+
+**Malik Willis** fez o banco. O QB reserva assinou um contrato de três anos e US$ 67,5 milhões com o Miami Dolphins — salário de titular. Bom para ele. O tempo em Green Bay ajudou a desenvolvê-lo, e os Dolphins claramente enxergam o potencial. Para onde Willis for, os torcedores dos Packers vão torcer por ele.
+
+No lado defensivo, as perdas se acumulam. **Quay Walker**, que estava se tornando um linebacker titular legítimo, assinou um contrato de três anos e US$ 40,5 milhões (US$ 28 milhões garantidos) em outro lugar. Ele estava melhorando cada vez mais. **Kingsley Enagbare** foi para o New York Jets por um contrato de um ano e US$ 10 milhões. E **Rasheed Walker** partiu para o Carolina Panthers num contrato de um ano. O setor de linebackers e a linha defensiva parecem bem diferentes para o verão.
+
+---
+
+## Agência Livre: As Chegadas
+
+O gerente geral Brian Gutekunst não ficou de braços cruzados.
+
+A maior aquisição foi uma **troca pelo linebacker Zaire Franklin** do Indianapolis Colts. Franklin é uma presença veterana comprovada — exatamente o tipo de voz experiente que uma defesa jovem precisa depois de perder Walker. Ele preenche o vazio de comunicação e liderança no setor de linebackers.
+
+O **center Sean Rhyan** ganhou um novo contrato após assumir a vaga titular no meio da temporada e nunca mais largar — ele foi titular nas últimas sete partidas da temporada regular mais o jogo dos playoffs. Continuidade na linha ofensiva importa, e a permanência de Rhyan mantém a linha intacta.
+
+O **defensive back Cox** foi mantido com um contrato de um ano e US$ 2,5 milhões. Uma decisão inteligente e econômica para a reserva.
+
+---
+
+## O Draft da NFL de 2026: Qualidade em Vez de Quantidade
+
+Green Bay entrou no draft com oito escolhas e saiu com seis jogadores selecionados — o menor draft class sob o mandato de Brian Gutekunst e o menor dos Packers desde 2004. A mensagem foi clara: apostar em talentos com alto potencial em vez de preencher cada lacuna com qualquer jogador disponível.
+
+**2ª Rodada, Pick 52 — CB Cisse:** O maior movimento. Com apenas 20 anos, Cisse é um dos jogadores mais jovens de toda a classe do draft, mas os analistas o projetam como um futuro CB1. Reportagens indicam que Gutekunst e sua equipe estavam "muito animados" com ele ao longo de todo o processo pré-draft. O cornerback era uma necessidade urgente, e os Packers foram lá e conseguiram alguém que acreditam que pode ser especial.
+
+**3ª Rodada (troca de posição) — DL McClellan:** Green Bay subiu sete posições a partir da 84ª escolha, cedendo uma quinta rodada para conseguir McClellan. Ele é uma presença interior versátil — pode ancorar o miolo mas também gerar algum rush ao quarterback. Após perder Enagbare, adicionar um jovem jogador de linha defensiva com potencial de crescimento era importante.
+
+**5ª Rodada — C/G Jager Burton:** Reserva na linha ofensiva com flexibilidade de posição — sempre útil.
+
+**6ª Rodada — CB Domani Jackson:** Mais competição e profundidade no setor defensivo. Depois de draftar Cisse, você aposta ainda mais no que acredita.
+
+**Agentes Livres Não Draftados:** Dez jogadores foram adicionados após o draft, incluindo o quarterback do Virginia Tech **Kyron Drones** — um passador dual-threat que participou de 41 jogos com 32 como titular na faculdade (5.785 jardas, 45 TDs). Ele não vai ameaçar o posto de Jordan Love, mas um QB em desenvolvimento com seu atletismo é exatamente o tipo de história de camp que deixa tudo mais interessante.
+
+---
+
+## Jordan Love e o Que Tudo Isso Significa
+
+Love entra no segundo ano de seu contrato de quatro anos e US$ 220 milhões (média de US$ 55 milhões por ano). Ele está contratado pelo coração desta reconstrução, e esta offseason sinaliza que Gutekunst está apostando em construir ao redor dele com talentos jovens em vez de veteranos caros.
+
+A temporada de 2025 mostrou o teto — Love pode jogar em alto nível, e quando o ataque funciona, os Packers podem vencer qualquer um. A temporada de 2025 também mostrou o chão — quando o time esfria, ele *realmente* esfria. Cinco derrotas seguidas. Uma vantagem de 21-3 no intervalo jogada fora.
+
+O elenco parece diferente agora. Os artilheiros estão mudando. Novas peças chegando. Mas o objetivo é o mesmo: dar o próximo passo, voltar aos playoffs e parar de perder logo no começo.
+
+Após três eliminações seguidas na primeira rodada, 2026 precisa ser o ano em que Green Bay avança do Wild Card.
+
+**Go Pack Go. 💛💚**
+
+---
+
+*Quer assistir a temporada de 2026 com outros fãs dos Packers no Brasil? Confira nossa [página de capítulos](/pt-BR/chapters/) para encontrar um watch party perto de você, ou entre na [comunidade WhatsApp do Cabeça de Queijo](/pt-BR/join/).*

--- a/src/content/blog/pt-BR/2026-05-offseason-update.md
+++ b/src/content/blog/pt-BR/2026-05-offseason-update.md
@@ -24,9 +24,9 @@ Toda offseason tem suas perdas, e essa doeu.
 
 **Romeo Doubs** vai embora após quatro temporadas em Green Bay. O homem que liderou o time em recepções em 2025 — 55 recepções, 724 jardas, seis touchdowns — está fora. Para um ataque de Jordan Love que precisa desesperadamente de artilheiros, perder seu alvo mais confiável é um golpe significativo. Os dois lados não conseguiram chegar a um acordo, e Doubs agora é problema de outra equipe.
 
-**Malik Willis** fez o banco. O QB reserva assinou um contrato de três anos e US$ 67,5 milhões com o Miami Dolphins — salário de titular. Bom para ele. O tempo em Green Bay ajudou a desenvolvê-lo, e os Dolphins claramente enxergam o potencial. Para onde Willis for, os torcedores dos Packers vão torcer por ele.
+**Malik Willis** fez o banco. De acordo com o tracker de agência livre da ESPN, o QB reserva assinou um contrato de três anos e US$ 67,5 milhões com o Miami Dolphins — salário de titular. Bom para ele. O tempo em Green Bay ajudou a desenvolvê-lo, e os Dolphins claramente enxergam o potencial. Para onde Willis for, os torcedores dos Packers vão torcer por ele.
 
-No lado defensivo, as perdas se acumulam. **Quay Walker**, que estava se tornando um linebacker titular legítimo, assinou um contrato de três anos e US$ 40,5 milhões (US$ 28 milhões garantidos) em outro lugar. Ele estava melhorando cada vez mais. **Kingsley Enagbare** foi para o New York Jets por um contrato de um ano e US$ 10 milhões. E **Rasheed Walker** partiu para o Carolina Panthers num contrato de um ano. O setor de linebackers e a linha defensiva parecem bem diferentes para o verão.
+No lado defensivo, as perdas se acumulam. Segundo a ESPN, **Quay Walker** — que estava se tornando um linebacker titular legítimo — assinou um contrato de três anos e US$ 40,5 milhões (US$ 28 milhões garantidos) em outro lugar. Ele estava melhorando cada vez mais. **Kingsley Enagbare** foi para o New York Jets por um contrato de um ano e US$ 10 milhões. E **Rasheed Walker** partiu para o Carolina Panthers num contrato de um ano. O setor de linebackers e a linha defensiva parecem bem diferentes para o verão.
 
 ---
 
@@ -36,17 +36,17 @@ O gerente geral Brian Gutekunst não ficou de braços cruzados.
 
 A maior aquisição foi uma **troca pelo linebacker Zaire Franklin** do Indianapolis Colts. Franklin é uma presença veterana comprovada — exatamente o tipo de voz experiente que uma defesa jovem precisa depois de perder Walker. Ele preenche o vazio de comunicação e liderança no setor de linebackers.
 
-O **center Sean Rhyan** ganhou um novo contrato após assumir a vaga titular no meio da temporada e nunca mais largar — ele foi titular nas últimas sete partidas da temporada regular mais o jogo dos playoffs. Continuidade na linha ofensiva importa, e a permanência de Rhyan mantém a linha intacta.
+Conforme divulgado pelo Packers.com, o **center Sean Rhyan** ganhou um novo contrato após assumir a vaga titular no meio da temporada e nunca mais largar — ele foi titular nas últimas sete partidas da temporada regular mais o jogo dos playoffs. Continuidade na linha ofensiva importa, e a permanência de Rhyan mantém a linha intacta.
 
-O **defensive back Cox** foi mantido com um contrato de um ano e US$ 2,5 milhões. Uma decisão inteligente e econômica para a reserva.
+O **defensive back Cox** foi mantido com um contrato de um ano e US$ 2,5 milhões, segundo o tracker da Lombardi Ave. Uma decisão inteligente e econômica para a reserva.
 
 ---
 
 ## O Draft da NFL de 2026: Qualidade em Vez de Quantidade
 
-Green Bay entrou no draft com oito escolhas e saiu com seis jogadores selecionados — o menor draft class sob o mandato de Brian Gutekunst e o menor dos Packers desde 2004. A mensagem foi clara: apostar em talentos com alto potencial em vez de preencher cada lacuna com qualquer jogador disponível.
+Green Bay entrou no draft com oito escolhas e saiu com seis jogadores selecionados — o menor draft class sob o mandato de Brian Gutekunst e o menor dos Packers desde 2004, de acordo com a Acme Packing Company. A mensagem foi clara: apostar em talentos com alto potencial em vez de preencher cada lacuna com qualquer jogador disponível.
 
-**2ª Rodada, Pick 52 — CB Cisse:** O maior movimento. Com apenas 20 anos, Cisse é um dos jogadores mais jovens de toda a classe do draft, mas os analistas o projetam como um futuro CB1. Reportagens indicam que Gutekunst e sua equipe estavam "muito animados" com ele ao longo de todo o processo pré-draft. O cornerback era uma necessidade urgente, e os Packers foram lá e conseguiram alguém que acreditam que pode ser especial.
+**2ª Rodada, Pick 52 — CB Cisse:** O maior movimento. Com apenas 20 anos, Cisse é um dos jogadores mais jovens de toda a classe do draft, mas os analistas o projetam como um futuro CB1. Segundo o resumo do draft da Acme Packing Company, Gutekunst e sua equipe estavam "muito animados" com ele ao longo de todo o processo pré-draft. O cornerback era uma necessidade urgente, e os Packers foram lá e conseguiram alguém que acreditam que pode ser especial.
 
 **3ª Rodada (troca de posição) — DL McClellan:** Green Bay subiu sete posições a partir da 84ª escolha, cedendo uma quinta rodada para conseguir McClellan. Ele é uma presença interior versátil — pode ancorar o miolo mas também gerar algum rush ao quarterback. Após perder Enagbare, adicionar um jovem jogador de linha defensiva com potencial de crescimento era importante.
 
@@ -54,13 +54,13 @@ Green Bay entrou no draft com oito escolhas e saiu com seis jogadores selecionad
 
 **6ª Rodada — CB Domani Jackson:** Mais competição e profundidade no setor defensivo. Depois de draftar Cisse, você aposta ainda mais no que acredita.
 
-**Agentes Livres Não Draftados:** Dez jogadores foram adicionados após o draft, incluindo o quarterback do Virginia Tech **Kyron Drones** — um passador dual-threat que participou de 41 jogos com 32 como titular na faculdade (5.785 jardas, 45 TDs). Ele não vai ameaçar o posto de Jordan Love, mas um QB em desenvolvimento com seu atletismo é exatamente o tipo de história de camp que deixa tudo mais interessante.
+**Agentes Livres Não Draftados:** Segundo o Packers.com, dez jogadores foram adicionados após o draft, incluindo o quarterback do Virginia Tech **Kyron Drones** — um passador dual-threat que participou de 41 jogos com 32 como titular na faculdade (5.785 jardas, 45 TDs). Ele não vai ameaçar o posto de Jordan Love, mas um QB em desenvolvimento com seu atletismo é exatamente o tipo de história de camp que deixa tudo mais interessante.
 
 ---
 
 ## Jordan Love e o Que Tudo Isso Significa
 
-Love entra no segundo ano de seu contrato de quatro anos e US$ 220 milhões (média de US$ 55 milhões por ano). Ele está contratado pelo coração desta reconstrução, e esta offseason sinaliza que Gutekunst está apostando em construir ao redor dele com talentos jovens em vez de veteranos caros.
+De acordo com o Spotrac, Love entra no segundo ano de seu contrato de quatro anos e US$ 220 milhões (média de US$ 55 milhões por ano, com US$ 160,3 milhões garantidos). Ele está contratado pelo coração desta reconstrução, e esta offseason sinaliza que Gutekunst está apostando em construir ao redor dele com talentos jovens em vez de veteranos caros.
 
 A temporada de 2025 mostrou o teto — Love pode jogar em alto nível, e quando o ataque funciona, os Packers podem vencer qualquer um. A temporada de 2025 também mostrou o chão — quando o time esfria, ele *realmente* esfria. Cinco derrotas seguidas. Uma vantagem de 21-3 no intervalo jogada fora.
 
@@ -73,3 +73,14 @@ Após três eliminações seguidas na primeira rodada, 2026 precisa ser o ano em
 ---
 
 *Quer assistir a temporada de 2026 com outros fãs dos Packers no Brasil? Confira nossa [página de capítulos](/pt-BR/chapters/) para encontrar um watch party perto de você, ou entre na [comunidade WhatsApp do Cabeça de Queijo](/pt-BR/join/).*
+
+---
+
+### Fontes
+
+- [Tracker de Agência Livre 2026 dos Packers — ESPN](https://www.espn.com/nfl/story/_/id/48089099/green-bay-packers-2026-free-agency-tracker-offseason-moves-signings-contract)
+- [Início do Ano Fiscal 2026: Resumo da Agência Livre — Packers.com](https://www.packers.com/news/2026-league-year-begins-for-packers-with-start-of-nfl-free-agency)
+- [Packers Assinam 5 Draftados e 10 Agentes Livres — Packers.com](https://www.packers.com/news/packers-sign-5-draft-picks-10-rookie-free-agents-may-1-2026)
+- [Resumo da Classe do Draft 2026 dos Packers — Acme Packing Company](https://www.acmepackingcompany.com/green-bay-packers-draft/81939/nfl-draft-results-2026-packers-class-rookies-recap)
+- [Tracker de Agência Livre 2026 — Lombardi Ave](https://lombardiave.com/green-bay-packers-free-agency-tracker-hub)
+- [Detalhes do Contrato de Jordan Love — Spotrac](https://www.spotrac.com/nfl/player/_/id/47621/jordan-love)


### PR DESCRIPTION

Adds per-source inline attributions (ESPN, Packers.com, Acme Packing
Company, Lombardi Ave, Spotrac) throughout the body text, plus a
Sources section at the bottom of both EN and PT-BR versions.

https://claude.ai/code/session_01U6gRPkyDnWWTnZ28XXLToJ